### PR TITLE
Improve performance

### DIFF
--- a/chezchat/main.py
+++ b/chezchat/main.py
@@ -18,18 +18,17 @@ def home():
     non_friend_users = []
     all_users = Users.query.all()
     all_rooms = Room.query.outerjoin(History).order_by(History.timestamp.desc().nullslast())
-    current_user_rooms = current_user.room_subscribed
+    current_user_rooms = current_user.room_subscribed.outerjoin(History).order_by(History.timestamp.desc().nullslast())
     rooms_ordered = []
     room_params = []
     notification_counts = []
-    for room in all_rooms:
-        if room in current_user_rooms:
-            last_message_params = room.room_history.order_by(None).order_by(History.timestamp.desc()).first()
-            room_notification_count = persistentNotifications(room.room_id)
-            rooms_ordered.append(room)
-            room_params.append(last_message_params)
-            notification_counts.append(room_notification_count)
-            print(room_notification_count)
+    for room in current_user_rooms:
+        last_message_params = room.room_history.order_by(None).order_by(History.timestamp.desc()).first()
+        room_notification_count = persistentNotifications(room.room_id)
+        rooms_ordered.append(room)
+        room_params.append(last_message_params)
+        notification_counts.append(room_notification_count)
+        print(room_notification_count)
     rooms = zip(rooms_ordered, room_params, notification_counts)
 
     # find users not in current_user's friend's list

--- a/chezchat/models.py
+++ b/chezchat/models.py
@@ -23,7 +23,7 @@ class Users(UserMixin, db.Model):
     user_history = db.relationship("History", backref="user_history", lazy="dynamic")
     room_created = db.relationship("Room", backref="room_created", lazy="dynamic")
     room_subscribed = db.relationship(
-        "Room", secondary=room_members, backref=db.backref("subscribers", lazy="dynamic")
+        "Room", secondary=room_members, backref=db.backref("subscribers", lazy="dynamic"), lazy="dynamic"
     )
 
     def set_password(self, password):


### PR DESCRIPTION
Initially, to get the rooms the current_user belonged to in an order sorted by the last message,
the entire room was iterated. added support to iterate only over the current user's rooms